### PR TITLE
Add command line color option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+img/result.png

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Run the following command and a file named `result.png` will be created under `i
 ```
 python3 binary_clock_wallpaper.py
 ```
+The accent color can be specified from the command line using the `--color` option:
+```
+python3 binary_clock_wallpaper.py --color "#35d8dd"
+```
 
 ### Running it as a cronjob
 You can run the helper script, `set_binary_wallpaper.sh`, as a cronjob to update your wallpaper every minute. The helper script uses `nitrogen` as wallpaper setter. Do not forget to change it if you use another program.

--- a/binary_clock_wallpaper.py
+++ b/binary_clock_wallpaper.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import re
 from PIL import Image, ImageDraw
 from datetime import datetime
 
@@ -7,12 +9,12 @@ base_image_path = os.path.join(base_dir, "img", "base.png")
 result_image_path = os.path.join(base_dir, "img", "result.png")
 
 
-def draw_unit(unit, xs, y, size):
+def draw_unit(unit, xs, y, size, accent_color="#FF2536"):
     print(unit)
     dots = bin(int(unit))[2:].zfill(len(xs))
     print(dots)
     for dot, x in zip(dots, xs):
-        color = "#FF2536" if dot == "1" else "#807675"
+        color = accent_color if dot == "1" else "#807675"
         draw.rectangle((x, y, x + size, y + size), fill=color)
 
 
@@ -20,6 +22,14 @@ time = datetime.now().strftime("%I:%M:%p")
 hour, minute, am_pm = time.split(":")
 am_pm = am_pm == "PM"
 
+accent_color = "#FF2536"
+args = sys.argv[1:]
+if len(args) != 0:
+    try:
+        if args[0] == "--color":
+            accent_color = args[1]
+    except IndexError:
+        print('error: Invalid command line arguments, using default color value')
 
 hour_xs = [543, 733, 940, 1133]
 hour_y = 292
@@ -32,8 +42,8 @@ size = 100
 im = Image.open(base_image_path)
 draw = ImageDraw.Draw(im)
 
-draw_unit(hour, hour_xs, hour_y, size)
-draw_unit(minute, minute_xs, minute_y, size)
-draw_unit(am_pm, [1560], 157, size)
+draw_unit(hour, hour_xs, hour_y, size, accent_color)
+draw_unit(minute, minute_xs, minute_y, size, accent_color)
+draw_unit(am_pm, [1560], 157, size, accent_color)
 
 im.save(result_image_path, quality=95)

--- a/set_binary_wallpaper.sh
+++ b/set_binary_wallpaper.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 base_dir=`dirname "$0"`
+if [ -f $base_dir/venv/bin/python ]; then
+    python=$base_dir/venv/bin/python
+else
+    python=python
+fi
 
-$base_dir/venv/bin/python $base_dir/binary_clock_wallpaper.py
+$python $base_dir/binary_clock_wallpaper.py
 
 ## Use any wallpaper setter of your choice. I use nitrogen
 nitrogen --set-zoom-fill $base_dir/img/result.png


### PR DESCRIPTION
This add a command line option to specify the accent color: 

```shell
python3 binary_clock_wallpaper.py --color 35d8dd
```
The color option can also be passed too the shell script:

```shell
./set_binary_wallpaper.sh --color
```
Command line arguments are captured using `sys.argv`, I figured using a library as `argparse` was a little bit overkill to add just one option but I could replace this by a real argument parser (with better error capturing and `--help` message) if you are interested.

Thank you for this cool little script!